### PR TITLE
Install enum reverse lookup constants

### DIFF
--- a/src/dynamic.cpp
+++ b/src/dynamic.cpp
@@ -337,8 +337,8 @@ void Dynamic::map_enum(pTHX_ const EnumDescriptor *descriptor, const string &per
                     newSVuv(value->number()));
 
         stringstream en;
-        en << "enum_";
         en << value->number();
+        en << "_ENUM";
         const std::string tmp = en.str();
         newCONSTSUB(stash, tmp.c_str(),
                     newSVpv(value->name().c_str(),0));

--- a/src/dynamic.cpp
+++ b/src/dynamic.cpp
@@ -1,6 +1,7 @@
 #include "dynamic.h"
 #include "mapper.h"
 
+#include <sstream>
 #include <google/protobuf/dynamic_message.h>
 
 using namespace gpd;
@@ -334,6 +335,13 @@ void Dynamic::map_enum(pTHX_ const EnumDescriptor *descriptor, const string &per
 
         newCONSTSUB(stash, value->name().c_str(),
                     newSVuv(value->number()));
+
+        stringstream en;
+        en << "enum_";
+        en << value->number();
+        const std::string tmp = en.str();
+        newCONSTSUB(stash, tmp.c_str(),
+                    newSVpv(value->name().c_str(),0));
     }
 }
 


### PR DESCRIPTION
This change adds enum_# constants to all enum classes. These methods can be used to lookup an enum key bases on the enum index. Will add docs and tests once you tell me which method name pattern to use.
