### PR TITLE
introduce plain accessors

### DIFF
--- a/src/dynamic.h
+++ b/src/dynamic.h
@@ -24,6 +24,7 @@ struct MappingOptions {
         GetAndSet = 1,
         PlainAndSet = 2,
         SingleAccessor = 3,
+        Plain = 4,
     };
 
     bool use_bigints;

--- a/t/220_accessor_style.t
+++ b/t/220_accessor_style.t
@@ -108,4 +108,40 @@ use t::lib::Test;
     is($map->string_int32_map('b'), 14);
 }
 
+{
+    my $d = Google::ProtocolBuffers::Dynamic->new('t/proto');
+    $d->load_file("scalar.proto");
+    $d->load_file("repeated.proto");
+    $d->load_file("extensions.proto");
+    $d->load_file("map_proto2.proto");
+    $d->map({ package => 'test', prefix => 'Test4', options => { accessor_style => 'plain', implicit_maps => 1 } });
+
+    my $scalar = Test4::Basic->new;
+    my $repeated = Test4::Repeated->new;
+    my $extensions = Test4::Message1->new;
+    my $map = Test4::Maps->new;
+
+    is($scalar->int32_f, 0);
+    $scalar->int32_f(2);
+    is($scalar->int32_f, 2);
+
+    $repeated->double_f([2]);
+    is($repeated->double_f->[0], 2);
+    eq_or_diff($repeated->double_f, [2]);
+    $repeated->double_f([7]);
+    eq_or_diff($repeated->double_f, [7]);
+    $repeated->double_f->[0] = 4;
+    eq_or_diff($repeated->double_f, [4]);
+
+    is($extensions->extension('test.value'), 0);
+    $extensions->extension('test.value', 7);
+    is($extensions->extension('test.value'), 7);
+
+    $map->string_int32_map({"a" => 7});
+    eq_or_diff($map->string_int32_map, { a => 7 });
+    $map->string_int32_map->{b} = 14;
+    eq_or_diff($map->string_int32_map, { a => 7, b => 14 });
+    is($map->string_int32_map->{b}, 14);
+}
+
 done_testing();


### PR DESCRIPTION
I'm porting some code from Google::ProtocolBuffers to Google::ProtocolBuffers::Dynamic, and so far the biggest problem is that GPBD uses different names for accessors for lists. What I would like to have is an option to have simplest accessors possible that return scalars for scalar values, and array or hash references for repeated and maps. This pull request implements such accessors. If you agree with adding such accessors in principle and have any suggestions, I would be happy to further amend the patch.