### PR TITLE
accept accessor_style option

### DIFF
--- a/lib/Google/ProtocolBuffers/Dynamic/MakeModule.pm
+++ b/lib/Google/ProtocolBuffers/Dynamic/MakeModule.pm
@@ -101,6 +101,10 @@ my %boolean_options = map +($_ => [$_, 1], "no_$_" => [$_, 0]), qw(
 sub _to_option {
     my ($options, $key, $value) = @_;
 
+    if ($key eq 'accessor_style') {
+        $options->{accessor_style} = $value;
+        return 1;
+    }
     return 0 unless my $boolean = $boolean_options{$key};
     $options->{$boolean->[0]} = $boolean->[1];
 

--- a/scripts/protoc-gen-perl-gpd
+++ b/scripts/protoc-gen-perl-gpd
@@ -67,4 +67,6 @@ C<generic_extension_methods>. When specified they set the option value
 to 1, when prefixed with C<no_> (e.g. C<no_use_bigints>) they set the
 option value to 0.
 
+String options: C<accessor_style> sets accessor_style option to the specified value
+
 =cut


### PR DESCRIPTION
Currently there's no way to specify accessor_style option when generating code with protoc