### PR TITLE
Fix decoding of empty strings

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -184,8 +184,13 @@ bool Mapper::DecoderHandlers::on_end_message(DecoderHandlers *cxt, upb::Status *
 }
 
 Mapper::DecoderHandlers *Mapper::DecoderHandlers::on_start_string(DecoderHandlers *cxt, const int *field_index, size_t size_hint) {
+    THX_DECLARE_AND_GET;
+
     cxt->mark_seen(field_index);
     cxt->string = cxt->get_target(field_index);
+    // if length of the string is zero initialize it with empty string
+    if (size_hint == 0)
+        sv_setpvn(cxt->string, "", 0);
 
     return cxt;
 }

--- a/t/210_encode_defaults.t
+++ b/t/210_encode_defaults.t
@@ -57,6 +57,17 @@ use t::lib::Test;
 
 {
     my $d = Google::ProtocolBuffers::Dynamic->new('t/proto');
+    $d->load_file("scalar.proto");
+    $d->map({ package => 'test', prefix => 'Test4', options => { encode_defaults => 1 } });
+
+    my $ref = bless { string_f => '' }, 'Test4::Basic';
+    my $decoded = Test4::Basic->decode(Test4::Basic->encode($ref));
+    eq_or_diff $decoded, $ref, "got the same structure back";
+    is $decoded->get_string_f, '', "empty string";
+}
+
+{
+    my $d = Google::ProtocolBuffers::Dynamic->new('t/proto');
     $d->load_file("options.proto");
     $d->map({ package => 'test', prefix => 'Test2', options => { encode_defaults => 0 } });
 


### PR DESCRIPTION
If protobuf contains empty string then `on_start_string` is called with `size_hint` set to 0, and `on_string` callback is never invoked, therefore SV is never initialized with any value and is `undef`. To fix that, this patch checks if `size_hint` is zero in `on_start_string`, and if it is then string is initialized with empty string.