### PR TITLE
accept string options (also client_services)

### DIFF
--- a/lib/Google/ProtocolBuffers/Dynamic/MakeModule.pm
+++ b/lib/Google/ProtocolBuffers/Dynamic/MakeModule.pm
@@ -98,11 +98,16 @@ my %boolean_options = map +($_ => [$_, 1], "no_$_" => [$_, 0]), qw(
     generic_extension_methods
 );
 
+my %string_options = map { $_ => 1 } qw(
+    accessor_style
+    client_services
+);
+
 sub _to_option {
     my ($options, $key, $value) = @_;
 
-    if ($key eq 'accessor_style') {
-        $options->{accessor_style} = $value;
+    if (exists $string_options{$key}) {
+        $options->{$key} = $value;
         return 1;
     }
     return 0 unless my $boolean = $boolean_options{$key};


### PR DESCRIPTION
[protoc-gen-perl-gpd document](http://search.cpan.org/~mbarbon/Google-ProtocolBuffers-Dynamic-0.20/scripts/protoc-gen-perl-gpd) says : 

> String options: accessor_style, client_services set the corresponding option to the specified value

but only `accessor_style` will be accepted.

`client_services` should be accepted.