### PR TITLE
Accept boolean option "implicit_maps" as documented

### DIFF
--- a/lib/Google/ProtocolBuffers/Dynamic/MakeModule.pm
+++ b/lib/Google/ProtocolBuffers/Dynamic/MakeModule.pm
@@ -90,6 +90,7 @@ sub _to_perl_package {
 }
 
 my %boolean_options = map +($_ => [$_, 1], "no_$_" => [$_, 0]), qw(
+    implicit_maps
     use_bigints
     check_required_fields
     explicit_defaults


### PR DESCRIPTION
Accept boolean option "implicit_maps", which is [documented](https://github.com/mbarbon/google-protobuf-dynamic/blob/master/scripts/protoc-gen-perl-gpd#L64), to protoc module generation.