### PR TITLE
Add `map_message_prefix` to automate message loading where there are dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /pod2htm?.tmp
 *.o
 *.obj
+GPATH
+GRTAGS
+GTAGS

--- a/lib/Google/ProtocolBuffers/Dynamic.pm
+++ b/lib/Google/ProtocolBuffers/Dynamic.pm
@@ -14,6 +14,7 @@ use Exporter ();
 XSLoader::load(__PACKAGE__);
 
 my $REQUIRED_MAP_PACKAGE_PREFIX = [qw(pb_prefix prefix)];
+my $REQUIRED_MAP_MESSAGE_PREFIX = [qw(message prefix)];
 my $REQUIRED_MAP_PACKAGE = [qw(package prefix)];
 my $REQUIRED_MAP_MESSAGE = [qw(message to)];
 my $REQUIRED_MAP_ENUM = [qw(enum to)];
@@ -26,6 +27,9 @@ sub map {
         if (exists $mapping->{pb_prefix}) {
             _check_keys($mapping, $REQUIRED_MAP_PACKAGE_PREFIX);
             $self->map_package_prefix($mapping->{pb_prefix}, $mapping->{prefix}, $mapping->{options});
+        } elsif (exists $mapping->{message} && exists $mapping->{prefix}) {
+            _check_keys($mapping, $REQUIRED_MAP_MESSAGE_PREFIX);
+            $self->map_message_prefix($mapping->{message}, $mapping->{prefix}, $mapping->{options});
         } elsif (exists $mapping->{package}) {
             _check_keys($mapping, $REQUIRED_MAP_PACKAGE);
             $self->map_package($mapping->{package}, $mapping->{prefix}, $mapping->{options});
@@ -353,6 +357,8 @@ format produced by C<protoc> C<--descriptor_set_out> option.
     $dynamic->map(
         # uses map_package_prefix
         { pb_prefix => $pb_prefix,prefix => $perl_prefix, options => $options },
+        # uses map_message_prefix
+        { message => $pb_message, prefix => $perl_prefix, options => $options },
         # uses map_package
         { package => $pb_package, prefix => $perl_prefix, options => $options },
         # uses map_message
@@ -404,6 +410,23 @@ C<OtherPackage::Foo>) by the first mapping.
 Finds all types contained in ProtocolBuffers packages having the given
 prefix and (recursively) maps them under the specified Perl package
 prefix. It silently skips any already mapped types.
+
+=head2 map_message_prefix
+
+    $dynamic->map_message_prefix($pb_message, $perl_prefix);
+    $dynamic->map_message_prefix($pb_message, $perl_prefix, $options);
+
+Maps the specified message (recursively) under the Perl package prefix,
+using the full package name of the message.  It silently skips any
+already mapped types (although it will still recurse in to them).
+
+In particular, this is quite usefull to automatically map a message
+that uses messages types defined in other packages.
+
+You might also want to map a required message to a specified package
+and then make sure other messages used by that message are mapped
+elsewhere.  This can be achieved by mapping with a prefix after mapping
+the message (since L</map_message_prefix> skips already-mapped stuff).
 
 =head2 map_package
 

--- a/src/dynamic.h
+++ b/src/dynamic.h
@@ -85,7 +85,7 @@ private:
     void map_service_noop(pTHX_ const google::protobuf::ServiceDescriptor *descriptor, const std::string &perl_package, const MappingOptions &options, ServiceDef *service_def);
     void map_service_grpc_xs(pTHX_ const google::protobuf::ServiceDescriptor *descriptor, const std::string &perl_package, const MappingOptions &options, ServiceDef *service_def);
     void check_package(pTHX_ const std::string &perl_package, const std::string &pb_name);
-	std::string pbname_to_package(const std::string &pb_name, const std::string &perl_package_prefix);
+    std::string pbname_to_package(pTHX_ const std::string &pb_name, const std::string &perl_package_prefix);
 
     OverlaySourceTree overlay_source_tree;
     DescriptorLoader descriptor_loader;
@@ -98,6 +98,7 @@ private:
     STD_TR1::unordered_set<std::string> mapped_enums;
     STD_TR1::unordered_set<std::string> mapped_services;
     STD_TR1::unordered_set<const google::protobuf::FileDescriptor *> files;
+    STD_TR1::unordered_set<std::string> recursed_names;
     std::vector<Mapper *> pending;
     std::vector<MethodMapper *> pending_methods;
 };

--- a/src/dynamic.h
+++ b/src/dynamic.h
@@ -64,6 +64,7 @@ public:
     void map_message(pTHX_ const std::string &message, const std::string &perl_package, const MappingOptions &options);
     void map_package(pTHX_ const std::string &pb_package, const std::string &perl_package_prefix, const MappingOptions &options);
     void map_package_prefix(pTHX_ const std::string &pb_prefix, const std::string &perl_package_prefix, const MappingOptions &options);
+    void map_message_prefix(pTHX_ const std::string &message, const std::string &perl_package_prefix, const MappingOptions &options);
     void map_enum(pTHX_ const std::string &enum_name, const std::string &perl_package, const MappingOptions &options);
     void map_service(pTHX_ const std::string &service_name, const std::string &perl_package, const MappingOptions &options);
     void resolve_references();
@@ -77,12 +78,14 @@ public:
 private:
     void map_package_or_prefix(pTHX_ const std::string &pb_package, bool is_prefix, const std::string &perl_package_prefix, const MappingOptions &options);
     void map_message_recursive(pTHX_ const google::protobuf::Descriptor *descriptor, const std::string &perl_package, const MappingOptions &options);
+    void map_message_prefix_recursive(pTHX_ const google::protobuf::Descriptor *descriptor, const std::string &perl_package_prefix, const MappingOptions &options);
     void map_message(pTHX_ const google::protobuf::Descriptor *descriptor, const std::string &perl_package, const MappingOptions &options);
     void map_enum(pTHX_ const google::protobuf::EnumDescriptor *descriptor, const std::string &perl_package, const MappingOptions &options);
     void map_service(pTHX_ const google::protobuf::ServiceDescriptor *descriptor, const std::string &perl_package, const MappingOptions &options);
     void map_service_noop(pTHX_ const google::protobuf::ServiceDescriptor *descriptor, const std::string &perl_package, const MappingOptions &options, ServiceDef *service_def);
     void map_service_grpc_xs(pTHX_ const google::protobuf::ServiceDescriptor *descriptor, const std::string &perl_package, const MappingOptions &options, ServiceDef *service_def);
     void check_package(pTHX_ const std::string &perl_package, const std::string &pb_name);
+	std::string pbname_to_package(const std::string &pb_name, const std::string &perl_package_prefix);
 
     OverlaySourceTree overlay_source_tree;
     DescriptorLoader descriptor_loader;

--- a/xsp/dynamic.xsp
+++ b/xsp/dynamic.xsp
@@ -30,6 +30,9 @@
     void map_package_prefix(const std::string &pb_package, const std::string &perl_package, SV *options = NULL)
         %code{% THIS->map_package_prefix(aTHX_ *pb_package, *perl_package, gpd::MappingOptions(aTHX_ options)); %};
 
+    void map_message_prefix(const std::string &pb_message, const std::string &perl_package_prefix, SV *options = NULL)
+        %code{% THIS->map_message_prefix(aTHX_ *pb_message, *perl_package_prefix, gpd::MappingOptions(aTHX_ options)); %};
+
     void resolve_references();
 
     static bool is_proto3();


### PR DESCRIPTION
Maps a message to a perl package prefix using the full protobuf message name as a perl package and recursively also map any messages it uses. See issue #27.