### PR TITLE
Parse incomplete map entries missing value as if value was default

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -276,6 +276,9 @@ Mapper::DecoderHandlers *Mapper::DecoderHandlers::on_start_map(DecoderHandlers *
         hv = (HV *) SvRV(target);
 
     cxt->mappers.push_back(mapper->fields[*field_index].mapper);
+    cxt->seen_fields.resize(cxt->seen_fields.size() + 1);
+    cxt->seen_fields.back().resize(2);
+    cxt->seen_fields.back()[0] = true; // never apply defaults to "key"
     cxt->items.push_back((SV *) hv);
     cxt->items.push_back(sv_newmortal());
     cxt->items.push_back(NULL);
@@ -284,6 +287,7 @@ Mapper::DecoderHandlers *Mapper::DecoderHandlers::on_start_map(DecoderHandlers *
 }
 
 bool Mapper::DecoderHandlers::on_end_map(DecoderHandlers *cxt, const int *field_index) {
+    cxt->seen_fields.pop_back();
     cxt->mappers.pop_back();
     cxt->items.pop_back();
     cxt->items.pop_back();
@@ -358,6 +362,7 @@ bool Mapper::DecoderHandlers::on_end_map_entry(DecoderHandlers *cxt, const int *
 
     SvOK_off(key);
     cxt->items[size - 1] = NULL;
+    cxt->seen_fields.back()[1] = false;
 
     return true;
 }

--- a/t/034_map_incomplete.t
+++ b/t/034_map_incomplete.t
@@ -1,0 +1,85 @@
+use t::lib::Test 'proto3';
+
+my $d = Google::ProtocolBuffers::Dynamic->new('t/proto');
+$d->load_file("map.proto");
+$d->map_message("test.Maps", "Maps", { explicit_defaults => 1 });
+$d->map_message("test.Item", "Item");
+$d->resolve_references();
+
+my %values = (
+    string_int32_map => [
+        {
+            "a" => 1,
+            "b" => 0,
+            ""  => 0,
+        },
+        {
+            a  => "\x0a\x05\x0a\x01a\x10\x01",
+            b  => "\x0a\x03\x0a\x01b",
+            "" => "\x0a\x04\x0a\x00\x10\x00"
+        },
+    ],
+    int32_string_map => [
+        {
+            2 => "a",
+            3 => "",
+            0 => "",
+        },
+        {
+            2 => "\x12\x05\x08\x02\x12\x01a",
+            3 => "\x12\x02\x08\x03",
+            0 => "\x12\x04\x08\x00\x12\x00",
+        },
+    ],
+    int32_bool_map => [
+        {
+            2 => "",
+            3 => 1,
+            0 => "",
+        },
+        {
+            2 => "\x1a\x02\x08\x02",
+            3 => "\x1a\x04\x08\x03\x10\x01",
+            0 => "\x1a\x04\x08\x00\x10\x00",
+        },
+    ],
+    bool_int32_map => [
+        {
+            1 => 0,
+            '' => 2,
+        },
+        {
+            1  => "\x22\x02\x08\x01",
+            '' => "\x22\x04\x08\x00\x10\x02",
+        },
+    ],
+    int32_enum_map => [
+        {
+            2 => 1,
+            3 => 2,
+            0 => 0,
+        },
+        {
+            2 => "\x2a\x04\x08\x02\x10\x01",
+            3 => "\x2a\x04\x08\x03\x10\x02",
+            0 => "\x2a\x02\x08\x00",
+        },
+    ],
+);
+
+sub encode {
+    my ($map, $parts) = @_;
+
+    return join('', map $parts->{$_}, sort keys %$map);
+}
+
+for my $field (sort keys %values) {
+    my ($values, $encoded) = @{$values{$field}};
+    my $bytes = Maps->encode({ $field => $values });
+    my $decoded = Maps->decode( encode($values, $encoded));
+
+    eq_or_diff($decoded, Maps->decode($bytes),
+               "$field - decode missing map values as default");
+}
+
+done_testing();


### PR DESCRIPTION
I'm trying to exchange data with an implementation which is using bare keys in maps.  It drops the value if it happens to match the default. Probably considering it redundant like any other default value.

GPD doesn't like such maps. It warns about "Incomplete map entry: missing value at..."  and drops the map entry.

Dropping the entry creates unnecessary problems.  I've been trying to get some guidance from the spec on https://developers.google.com/protocol-buffers/docs/proto3#maps but it's pretty confusing:

> If you provide a key but no value for a map field, the behavior when the field is serialized is language-dependent. In C++, Java, Kotlin, and Python the default value for the type is serialized, while in other languages nothing is serialized.

It's unclear whether "nothing" means "no map entry" or "no value".  But I believe the latter is the only reasonable interpretation, matching what we observe.  It is impossible to deserialize "no map entry".  So I assume the intended meaning is "no value".   Which implies that this should be deserialized as a default value.

This is a straight forward attempt to fix this issue by enabling the "seen" flag for values in map entries. Missing values in maps are then processed by apply_defaults_and_check() like any other missing value, being set to default if "explicit_defaults" is enabled.

I wasn't sure if this should be hidden behind separate flag.  Maybe it should?  Or maybe it should be uncondifitonally enabled?

Note that map keys are not subject to default replacement.  This is ensured by simply leaving the key "seen" flag set.

EDIT:  First implementation was a mess.  Sorry about that.  Force pushed a saner solution just now.