### PR TITLE
Use booleans in service introspection test

### DIFF
--- a/t/357_service_introspection.t
+++ b/t/357_service_introspection.t
@@ -1,5 +1,10 @@
 use t::lib::Test 'proto3';
 
+use constant {
+    true  => !!1,
+    false => !!0,
+};
+
 use Google::ProtocolBuffers::Dynamic qw(:descriptor :values);
 
 {
@@ -37,8 +42,8 @@ sub check_mapping {
     my @methods = sort { $a->name cmp $b->name } @$methods;
 
     eq_or_diff(method_attrs($methods[0]), {
-        client_streaming    => 1,
-        server_streaming    => '',
+        client_streaming    => true,
+        server_streaming    => false,
         name                => 'JoinedHello',
         service             => 'helloworld.Greeter',
         full_name           => 'helloworld.Greeter.JoinedHello',
@@ -47,8 +52,8 @@ sub check_mapping {
     });
 
     eq_or_diff(method_attrs($methods[1]), {
-        client_streaming    => '',
-        server_streaming    => '',
+        client_streaming    => false,
+        server_streaming    => false,
         name                => 'SayHello',
         service             => 'helloworld.Greeter',
         full_name           => 'helloworld.Greeter.SayHello',
@@ -57,8 +62,8 @@ sub check_mapping {
     });
 
     eq_or_diff(method_attrs($methods[2]), {
-        client_streaming    => '',
-        server_streaming    => 1,
+        client_streaming    => false,
+        server_streaming    => true,
         name                => 'SplitHello',
         service             => 'helloworld.Greeter',
         full_name           => 'helloworld.Greeter.SplitHello',
@@ -67,8 +72,8 @@ sub check_mapping {
     });
 
     eq_or_diff(method_attrs($methods[3]), {
-        client_streaming    => 1,
-        server_streaming    => 1,
+        client_streaming    => true,
+        server_streaming    => true,
         name                => 'WavingHello',
         service             => 'helloworld.Greeter',
         full_name           => 'helloworld.Greeter.WavingHello',


### PR DESCRIPTION
With the release of 5.36.0, Perl got real boolean values which try to behave like the traditional `1` and `''` in older versions. However, starting with 5.37.2, Data::Dumper stringifies these differently. "True", for example, goes from `1` to being `!!1`.

This is of no consequence for Perl, but was resulting in the service introspection test failing in versions of Perl greater than 5.37.2 because the changes in the built-in Data::Dumper were making Test::Differences report a false positive. See https://github.com/DrHyde/perl-modules-Test-Differences/issues/21 for some additional context.

This patch fixes this by storing the result of what the current version of Perl considers to be "true" and "false" in constants, and using those in the test whenever they are needed. This makes the tests pass again under newer perls.

Fixes #48 